### PR TITLE
use OS::Nova::Server resource

### DIFF
--- a/cassandra-node.yaml
+++ b/cassandra-node.yaml
@@ -72,7 +72,7 @@ parameters:
 resources:
 
   node_server:
-    type: "Rackspace::Cloud::Server"
+    type: "OS::Nova::Server"
     properties:
       name: { get_param: node_hostname }
       flavor: { get_param: flavor }
@@ -92,9 +92,9 @@ resources:
       chef_version: { get_param: chef_version }
       node:
         cassandra:
-          listen_address: { get_attr: [node_server, privateIPv4] }
-          broadcast_address: { get_attr: [node_server, privateIPv4] }
-          rpc_address: { get_attr: [node_server, privateIPv4] }
+          listen_address: { get_attr: [node_server, networks, private, 0] }
+          broadcast_address: { get_attr: [node_server, networks, private, 0] }
+          rpc_address: { get_attr: [node_server, networks, private, 0] }
           seeds: [ { get_param: seed } ]
         java:
           jdk_version: 7
@@ -115,4 +115,4 @@ outputs:
 
   private_ip:
     description: "Private IP of Cassandra node"
-    value: { get_attr: [node_server, privateIPv4] }
+    value: { get_attr: [node_server, networks, private, 0] }

--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -110,7 +110,7 @@ parameters:
     label: Child Template
     description: URL to the child template for deploying Cassandra nodes.
     type: string
-    default: https://raw.githubusercontent.com/rackspace-orchestration-templates/cassandra/master/cassandra-node.yaml
+    default: http://drop.duncancreek.net/cassandra-node.yaml # https://raw.githubusercontent.com/rackspace-orchestration-templates/cassandra/master/cassandra-node.yaml
 
 resources:
   # SSH Key
@@ -122,7 +122,7 @@ resources:
 
   # Server resources
   seed_node:
-    type: "Rackspace::Cloud::Server"
+    type: "OS::Nova::Server"
     properties:
       name: { get_param: seed_hostname }
       flavor: { get_param: flavor }
@@ -141,10 +141,10 @@ resources:
       chef_version: { get_param: chef_version }
       node:
         cassandra:
-          listen_address: { get_attr: [seed_node, privateIPv4] }
-          broadcast_address: { get_attr: [seed_node, privateIPv4] }
-          rpc_address: { get_attr: [seed_node, privateIPv4] }
-          seeds: { get_attr: [seed_node, privateIPv4] }
+          listen_address: { get_attr: [seed_node, networks, private, 0] }
+          broadcast_address: { get_attr: [seed_node, networks, private, 0] }
+          rpc_address: { get_attr: [seed_node, networks, private, 0] }
+          seeds: { get_attr: [seed_node, networks, private, 0] }
         java:
           jdk_version: 7
         rax:
@@ -171,7 +171,7 @@ resources:
           flavor: { get_param: flavor }
           kitchen: { get_param: kitchen }
           chef_version: { get_param: chef_version }
-          seed: { get_attr: [seed_node, privateIPv4] }
+          seed: { get_attr: [seed_node, networks, private, 0] }
           ssh_keypair_name: { get_resource: ssh_key }
           ssh_private_key: { get_attr: [ssh_key, private_key] }
           ssh_public_key: { get_attr: [ssh_key, public_key] }

--- a/cassandra.yaml
+++ b/cassandra.yaml
@@ -110,7 +110,7 @@ parameters:
     label: Child Template
     description: URL to the child template for deploying Cassandra nodes.
     type: string
-    default: http://drop.duncancreek.net/cassandra-node.yaml # https://raw.githubusercontent.com/rackspace-orchestration-templates/cassandra/master/cassandra-node.yaml
+    default: https://raw.githubusercontent.com/rackspace-orchestration-templates/cassandra/master/cassandra-node.yaml
 
 resources:
   # SSH Key


### PR DESCRIPTION
Rackspace::Cloud::Server is deprecated. Attribute changes require us to
reference the private IP differently.